### PR TITLE
[BUGFIX] Exclude `.php-cs-fixer.cache` file in new projects

### DIFF
--- a/templates/src/.gitignore.twig
+++ b/templates/src/.gitignore.twig
@@ -14,5 +14,8 @@
 # Temporary files
 /var/
 
+# Test files
+/.php-cs-fixer.cache
+
 # Composer-related files
 /vendor/


### PR DESCRIPTION
With this PR, cache files of PHP-CS-Fixer are now excluded from Git in new project files.