### PR TITLE
[BUGFIX] Add `armin/editorconfig-cli` to `composer.json` template

### DIFF
--- a/templates/src/composer.json.twig
+++ b/templates/src/composer.json.twig
@@ -37,6 +37,7 @@
 		"typo3/cms-viewpage": "^{{ packages.typo3_cms }}"
 	},
 	"require-dev": {
+		"armin/editorconfig-cli": "^1.5",
 {% if features.deployer %}
 		"deployer/deployer": "^7.0",
 {% endif %}


### PR DESCRIPTION
The Composer scripts `lint:editorconfig` and `fix:editorconfig` require the package `armin/editorconfig-cli` to be installed.