### PR TITLE
[BUGFIX] Use correct syntax to find package paths for PHPStan analyze

### DIFF
--- a/templates/src/composer.json.twig
+++ b/templates/src/composer.json.twig
@@ -111,7 +111,7 @@
 		"sca": [
 			"@sca:php"
 		],
-		"sca:php": "phpstan analyse -c phpstan.neon --memory-limit=2G $(find packages/* -type d -maxdepth 1 -name 'Classes' -o -name 'Configuration' -o -name 'Tests')",
+		"sca:php": "phpstan analyse -c phpstan.neon --memory-limit=2G $(find packages -mindepth 2 -maxdepth 2 -type d -name 'Classes' -o -name 'Configuration' -o -name 'Tests')",
 {% endif %}
 		"typo3-cms-scripts": [
 			"typo3cms install:fixfolderstructure"


### PR DESCRIPTION
The previously used syntax did not always find the correct paths to package files used for PHPStan analyze.