### PR TITLE
[BUGFIX] Re-enable commented opcache clear in deploy.php template

### DIFF
--- a/templates/src/deploy.php
+++ b/templates/src/deploy.php
@@ -134,7 +134,7 @@ after('deploy:symlink', function () {
     invoke('typo3:extension_setup');
     invoke('typo3:upgrade_all');
     invoke('typo3:cache_flush');
-//    invoke('cachetool:clear:opcache');
+    invoke('cachetool:clear:opcache');
     invoke('typo3:cache_warmup');
 });
 


### PR DESCRIPTION
The `cachetool:clear:opcache` task invocation was disabled by accident. It is now re-enabled.