### PR TITLE
[BUGFIX] Remove superfluous `allow-plugins` configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,7 @@
 	},
 	"config": {
 		"allow-plugins": {
-			"composer/installers": false,
-			"ergebnis/composer-normalize": true,
-			"oomphinc/composer-installers-extender": false,
-			"wikimedia/composer-merge-plugin": false
+			"ergebnis/composer-normalize": true
 		},
 		"sort-packages": true
 	},


### PR DESCRIPTION
This PR removes some outdated plugins from the `allow-plugins` configuration. Those became obsolete with the release of Project Builder 1.0.0. 