### PR TITLE
[BUGFIX] Provide default value for DDEV database version

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -169,6 +169,7 @@ properties:
       - identifier: db_version
         name: Database version
         type: staticValue
+        defaultValue: "{% if ddev.db_driver == \"MySQL\" %}8.0{% else %}10.4{% endif %}"
         validators:
           - type: notEmpty
 


### PR DESCRIPTION
This PR provides default values for the selected database version used within DDEV. The following default values are configured:

* [x] MySQL 8.0
* [x] MariaDB 10.4