### PR TITLE
[BUGFIX] Use default versioning strategy for Dependabot Composer updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,4 +23,3 @@ updates:
     labels:
       - dependencies
     open-pull-requests-limit: 10
-    versioning-strategy: widen


### PR DESCRIPTION
The default versioning strategy should be good enough for this package. With the current setting, no updates are possible.