### PR TITLE
[DOCS] fix contribution requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,6 @@ Thanks for considering contributing to this project! Each contribution is
 highly appreciated. In order to maintain a high code quality, please follow
 all steps below.
 
-## Requirements
-
-- Composer
-- PHP >= 8.1
-
 ## Preparation
 
 ```bash


### PR DESCRIPTION
Until now we stated a requirements in the `Contribution.md` as follows:

```markdown
## Requirements

- Composer
- PHP >= 8.1
```

This is both incorrect and imho unnecessary since the PHP requirement actually derives from the [Project Builder](https://github.com/CPS-IT/project-builder) which states `PHP >= 8.0`. Also, again my humble opinion, `Composer` should be a no-brainer in this context. The only requirement worth mentioning is probably `Docker` which is needed to run:

```bash
composer validate-schema
``` 

However, this requirement is disclaimed in the adjacent bash snippet.