### PR TITLE
[TASK] Use TYPO3 v12.3 as available version for new projects

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -58,7 +58,7 @@ properties:
         name: TYPO3 version
         type: select
         options:
-          - value: 12.2
+          - value: 12.3
           - value: 11.5
         validators:
           - type: notEmpty
@@ -67,7 +67,7 @@ properties:
         type: dynamicSelect
         options:
           - value: '^7.0@dev'
-            if: 'packages["typo3_cms"] == "12.2"'
+            if: 'packages["typo3_cms"] == "12.3"'
           - value: '^6.16'
             if: 'packages["typo3_cms"] == "11.5"'
       - identifier: typo3_console
@@ -75,7 +75,7 @@ properties:
         type: dynamicSelect
         options:
           - value: '^8.0'
-            if: 'packages["typo3_cms"] == "12.2"'
+            if: 'packages["typo3_cms"] == "12.3"'
           - value: '^7.0.3'
             if: 'packages["typo3_cms"] == "11.5"'
       - identifier: typo3_console_binary
@@ -83,7 +83,7 @@ properties:
         type: dynamicSelect
         options:
           - value: 'typo3'
-            if: 'packages["typo3_cms"] == "12.2"'
+            if: 'packages["typo3_cms"] == "12.3"'
           - value: 'typo3cms'
             if: 'packages["typo3_cms"] == "11.5"'
       - identifier: php

--- a/templates/next-steps.html.twig
+++ b/templates/next-steps.html.twig
@@ -10,7 +10,7 @@ Run <comment>ddev config --auto</comment> to create the final DDEV configuration
 
 You can now launch your installed project with <comment>ddev launch</comment>.
 Follow all installation instructions to finalize the TYPO3 installation.
-{% if packages.typo3_cms == "12.2" %}
+{% if packages.typo3_cms == "12.3" %}
 You can also run <comment>ddev typo3 setup</comment> to complete the installation process.
 {% endif %}
 

--- a/templates/src/composer.json.twig
+++ b/templates/src/composer.json.twig
@@ -56,7 +56,7 @@
 {% if features.phpstan %}
 		"saschaegerer/phpstan-typo3": "^1.8",
 {% endif %}
-{% if packages.typo3_cms == "12.2" %}
+{% if packages.typo3_cms == "12.3" %}
 		"sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": "^0.1.2",
 {% endif %}
 {% if features.rector %}
@@ -77,7 +77,7 @@
 {% if features.phpstan %}
 			"phpstan/extension-installer": true,
 {% endif %}
-{% if packages.typo3_cms == "12.2" %}
+{% if packages.typo3_cms == "12.3" %}
 			"sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": true,
 {% endif %}
 			"typo3/class-alias-loader": true,


### PR DESCRIPTION
With today's sprint release of TYPO3 v12, we can now switch the available TYPO3 version for new projects from `12.2` to `12.3`.