### PR TITLE
[FEATURE] Allow selection of additional system extensions

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -96,6 +96,22 @@ properties:
             if: 'packages["typo3_cms"] == "11.5"'
         validators:
           - type: notEmpty
+      - identifier: typo3_system_extensions
+        name: Do you need additional TYPO3 system extensions?
+        type: select
+        multiple: true
+        options:
+          - value: 'typo3/cms-felogin'
+          - value: 'typo3/cms-filemetadata'
+          - value: 'typo3/cms-indexed-search'
+          - value: 'typo3/cms-linkvalidator'
+          - value: 'typo3/cms-reactions'
+            if: 'packages["typo3_cms"] == "12.3"'
+          - value: 'typo3/cms-sys-note'
+          - value: 'typo3/cms-t3editor'
+          - value: 'typo3/cms-webhooks'
+            if: 'packages["typo3_cms"] == "12.3"'
+          - value: 'typo3/cms-workspaces'
 
   # Features
   - identifier: features

--- a/templates/src/composer.json.twig
+++ b/templates/src/composer.json.twig
@@ -12,6 +12,9 @@
 	"homepage": "{{ project.url }}",
 	"require": {
 		"helhum/typo3-console": "{{ packages.typo3_console }}",
+{% for additional_package in packages.typo3_system_extensions %}
+		"{{ additional_package }}": "^{{ packages.typo3_cms }}",
+{% endfor %}
 		"typo3/cms-adminpanel": "^{{ packages.typo3_cms }}",
 		"typo3/cms-backend": "^{{ packages.typo3_cms }}",
 		"typo3/cms-belog": "^{{ packages.typo3_cms }}",


### PR DESCRIPTION
This PR adds the possibility to select additional TYPO3 system extensions during project generation. Those will be added to the final `composer.json`.