### PR TITLE
[FEATURE] Switch to TYPO3 v12.4 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ ready-to-use DDEV configuration and basic configuration for deployment with Depl
 
 * Composer-based [TYPO3 CMS](https://typo3.org) project template
 * Ready-to-use [DDEV](https://ddev.readthedocs.io) configuration
-* Compatible with TYPO3 11.5 LTS
+* Compatible with TYPO3 11.5 LTS and 12.4 LTS
 * Support of current stable PHP versions, starting from PHP 8.0
 
 ### Optional features

--- a/config.yaml
+++ b/config.yaml
@@ -58,7 +58,7 @@ properties:
         name: TYPO3 version
         type: select
         options:
-          - value: 12.3
+          - value: 12.4
           - value: 11.5
         validators:
           - type: notEmpty
@@ -67,7 +67,7 @@ properties:
         type: dynamicSelect
         options:
           - value: '^7.0@dev'
-            if: 'packages["typo3_cms"] == "12.3"'
+            if: 'packages["typo3_cms"] == "12.4"'
           - value: '^6.16'
             if: 'packages["typo3_cms"] == "11.5"'
       - identifier: typo3_console
@@ -75,7 +75,7 @@ properties:
         type: dynamicSelect
         options:
           - value: '^8.0'
-            if: 'packages["typo3_cms"] == "12.3"'
+            if: 'packages["typo3_cms"] == "12.4"'
           - value: '^7.0.3'
             if: 'packages["typo3_cms"] == "11.5"'
       - identifier: typo3_console_binary
@@ -83,7 +83,7 @@ properties:
         type: dynamicSelect
         options:
           - value: 'typo3'
-            if: 'packages["typo3_cms"] == "12.3"'
+            if: 'packages["typo3_cms"] == "12.4"'
           - value: 'typo3cms'
             if: 'packages["typo3_cms"] == "11.5"'
       - identifier: php
@@ -106,11 +106,11 @@ properties:
           - value: 'typo3/cms-indexed-search'
           - value: 'typo3/cms-linkvalidator'
           - value: 'typo3/cms-reactions'
-            if: 'packages["typo3_cms"] == "12.3"'
+            if: 'packages["typo3_cms"] == "12.4"'
           - value: 'typo3/cms-sys-note'
           - value: 'typo3/cms-t3editor'
           - value: 'typo3/cms-webhooks'
-            if: 'packages["typo3_cms"] == "12.3"'
+            if: 'packages["typo3_cms"] == "12.4"'
           - value: 'typo3/cms-workspaces'
 
   # Features

--- a/templates/next-steps.html.twig
+++ b/templates/next-steps.html.twig
@@ -10,7 +10,7 @@ Run <comment>ddev config --auto</comment> to create the final DDEV configuration
 
 You can now launch your installed project with <comment>ddev launch</comment>.
 Follow all installation instructions to finalize the TYPO3 installation.
-{% if packages.typo3_cms == "12.3" %}
+{% if packages.typo3_cms == "12.4" %}
 You can also run <comment>ddev typo3 setup</comment> to complete the installation process.
 {% endif %}
 

--- a/templates/src/composer.json.twig
+++ b/templates/src/composer.json.twig
@@ -59,7 +59,7 @@
 {% if features.phpstan %}
 		"saschaegerer/phpstan-typo3": "^1.8",
 {% endif %}
-{% if packages.typo3_cms == "12.3" %}
+{% if packages.typo3_cms == "12.4" %}
 		"sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": "^0.1.2",
 {% endif %}
 {% if features.rector %}
@@ -80,7 +80,7 @@
 {% if features.phpstan %}
 			"phpstan/extension-installer": true,
 {% endif %}
-{% if packages.typo3_cms == "12.3" %}
+{% if packages.typo3_cms == "12.4" %}
 			"sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": true,
 {% endif %}
 			"typo3/class-alias-loader": true,


### PR DESCRIPTION
With the release of TYPO3 v12.4 LTS, we can now switch to the stable version for new projects.