### PR TITLE
[BUGFIX] Do not require typo3/cms-recordlist for TYPO3 v12 projects

### DIFF
--- a/templates/src/composer.json.twig
+++ b/templates/src/composer.json.twig
@@ -33,7 +33,9 @@
 		"typo3/cms-install": "^{{ packages.typo3_cms }}",
 		"typo3/cms-lowlevel": "^{{ packages.typo3_cms }}",
 		"typo3/cms-opendocs": "^{{ packages.typo3_cms }}",
+{% if packages.typo3_cms != "12.4" %}
 		"typo3/cms-recordlist": "^{{ packages.typo3_cms }}",
+{% endif %}
 		"typo3/cms-recycler": "^{{ packages.typo3_cms }}",
 		"typo3/cms-redirects": "^{{ packages.typo3_cms }}",
 		"typo3/cms-reports": "^{{ packages.typo3_cms }}",


### PR DESCRIPTION
EXT:recordlist was merged into EXT:backend with TYPO3 12.0. See https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-98443-ExtensionRecordlistMergedIntoBackend.html for reference.