### PR TITLE
[FEATURE] Switch to stable versions of TYPO3 testing framework

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -66,9 +66,9 @@ properties:
         name: TYPO3 testing framework version
         type: dynamicSelect
         options:
-          - value: '^7.0@dev'
+          - value: '^8.0'
             if: 'packages["typo3_cms"] == "12.4"'
-          - value: '^6.16'
+          - value: '^7.0'
             if: 'packages["typo3_cms"] == "11.5"'
       - identifier: typo3_console
         name: TYPO3 console version

--- a/templates/src/composer.json.twig
+++ b/templates/src/composer.json.twig
@@ -61,9 +61,6 @@
 {% if features.phpstan %}
 		"saschaegerer/phpstan-typo3": "^1.8",
 {% endif %}
-{% if packages.typo3_cms == "12.4" %}
-		"sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": "^0.1.2",
-{% endif %}
 {% if features.rector %}
 		"ssch/typo3-rector": "^1.0",
 {% endif %}
@@ -81,9 +78,6 @@
 			"ergebnis/composer-normalize": true,
 {% if features.phpstan %}
 			"phpstan/extension-installer": true,
-{% endif %}
-{% if packages.typo3_cms == "12.4" %}
-			"sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": true,
 {% endif %}
 			"typo3/class-alias-loader": true,
 			"typo3/cms-composer-installers": true


### PR DESCRIPTION
With yesterday's TYPO3 v12 LTS release, new stable versions of TYPO3 testing framework were released as well. The new versions are now used for new projects:

- TYPO3 11.5: TYPO3 testing framework v7
- TYPO3 12.4: TYPO3 testing framework v8