### PR TITLE
[BUGFIX] Skip deploy.php.twig if Deployer feature is disabled

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,7 @@ steps:
         # Deployer
         - path: '.deployment/*'
           if: 'features["deployer"]'
-        - path: 'deploy.php'
+        - path: 'deploy.php.twig'
           if: 'features["deployer"]'
         # PHPStan
         - path: 'phpstan.neon'


### PR DESCRIPTION
The `deploy.php.twig` file was referenced as resolved file (`deploy.php`) instead of its source template file (`deploy.php.twig`). This is now fixed and a `deploy.php` file will no longer be processed if the Deployer feature is disabled.