### PR TITLE
[TASK] Explicitly report abandoned packages with `audit` command

### DIFF
--- a/templates/src/composer.json.twig
+++ b/templates/src/composer.json.twig
@@ -82,6 +82,9 @@
 			"typo3/class-alias-loader": true,
 			"typo3/cms-composer-installers": true
 		},
+		"audit": {
+			"abandoned": "report"
+		},
 		"platform": {
 			"php": "{{ get_latest_stable_php_version(packages.php) }}"
 		},


### PR DESCRIPTION
Composer 2.6 introduced a new way of handling abandoned packages when running `composer audit`. By now, abandoned packages will be reported only, but the command will not fail in case abandoned packages are required. This changes with Composer 2.7 where it will cause `composer audit` to fail in such cases.

With this PR, the configuration option `audit.abandoned` is explicitly configured as `report` to avoid failures on `composer audit` when using abandoned packages.