### PR TITLE
[TASK] Enable `ConfigNoCache` sniff in TypoScript linter

### DIFF
--- a/templates/src/typoscript-lint.yml.twig
+++ b/templates/src/typoscript-lint.yml.twig
@@ -20,3 +20,4 @@ sniffs:
   - class: NestingConsistency
     parameters:
       commonPathPrefixThreshold: 1
+  - class: ConfigNoCache


### PR DESCRIPTION
This PR enables the `ConfigNoCache` sniff in `typoscript-lint.yml` template.