### PR TITLE
[TASK] Sync indentation within TypoScript files

### DIFF
--- a/templates/src/typoscript-lint.yml.twig
+++ b/templates/src/typoscript-lint.yml.twig
@@ -7,7 +7,7 @@ sniffs:
   - class: Indentation
     parameters:
       useSpaces: true
-      indentPerLevel: 4
+      indentPerLevel: 2
       indentConditions: false
   - class: DeadCode
   - class: OperatorWhitespace


### PR DESCRIPTION
This PR syncs indentation within TypoScript file in `typoscript-lint.yml`. The indentation level is configured in `.editorconfig` template.