### PR TITLE
[FEATURE] Allow PHP 8.3 as selectable PHP version for new projects

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -90,6 +90,7 @@ properties:
         name: PHP version
         type: select
         options:
+          - value: '8.3'
           - value: '8.2'
           - value: '8.1'
           - value: '8.0'


### PR DESCRIPTION
This PR adds PHP 8.3 to the list of selectable PHP versions for new projects.