### PR TITLE
[TASK] Add support for `armin/editorconfig-cli` ^2.0 in template

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -97,6 +97,14 @@ properties:
             if: 'packages["typo3_cms"] == "11.5"'
         validators:
           - type: notEmpty
+      - identifier: editorconfig_cli
+        name: Editorconfig CLI version
+        type: dynamicSelect
+        options:
+          - value: '^2.0'
+            if: 'packages["php"] in ["8.2", "8.3"]'
+          - value: '^1.5'
+            if: 'packages["php"] in ["8.0", "8.1"]'
       - identifier: typo3_system_extensions
         name: Do you need additional TYPO3 system extensions?
         type: select

--- a/templates/src/composer.json.twig
+++ b/templates/src/composer.json.twig
@@ -47,7 +47,7 @@
 		"typo3/cms-viewpage": "^{{ packages.typo3_cms }}"
 	},
 	"require-dev": {
-		"armin/editorconfig-cli": "^1.5",
+		"armin/editorconfig-cli": "{{ packages.editorconfig_cli }}",
 {% if features.deployer %}
 		"deployer/deployer": "^7.0",
 {% endif %}


### PR DESCRIPTION
This PR dynamically configures the version constraint for `armin/editorconfig-cli` to support `^2.0` as well. This is especially relevant for projects with Symfony v7.