### PR TITLE
[TASK] Let Renovate update template version constraints

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -66,7 +66,7 @@ properties:
         name: TYPO3 testing framework version
         type: dynamicSelect
         options:
-          - value: '^8.0'
+          - value: '^8.0' # renovate: datasource=packagist depName=typo3/testing-framework
             if: 'packages["typo3_cms"] == "12.4"'
           - value: '^7.0'
             if: 'packages["typo3_cms"] == "11.5"'
@@ -74,7 +74,7 @@ properties:
         name: TYPO3 console version
         type: dynamicSelect
         options:
-          - value: '^8.0'
+          - value: '^8.0' # renovate: datasource=packagist depName=helhum/typo3-console
             if: 'packages["typo3_cms"] == "12.4"'
           - value: '^7.0.3'
             if: 'packages["typo3_cms"] == "11.5"'
@@ -101,7 +101,7 @@ properties:
         name: Editorconfig CLI version
         type: dynamicSelect
         options:
-          - value: '^2.0'
+          - value: '^2.0' # renovate: datasource=packagist depName=armin/editorconfig-cli
             if: 'packages["php"] in ["8.2", "8.3"]'
           - value: '^1.5'
             if: 'packages["php"] in ["8.0", "8.1"]'

--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,36 @@
 	],
 	"assignees": [
 		"eliashaeussler"
+	],
+	"customManagers": [
+		{
+			"customType": "regex",
+			"fileMatch": [
+				"^config\\.yaml$"
+			],
+			"matchStrings": [
+				"value: '(?<currentValue>[^']+)' # renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)"
+			]
+		},
+		{
+			"customType": "regex",
+			"fileMatch": [
+				"^templates/src/composer\\.json\\.twig$"
+			],
+			"matchStrings": [
+				"\"(?<depName>[\\w-]+/[\\w-]+)\": \"(?<currentValue>[^\"\\s]+)\""
+			],
+			"datasourceTemplate": "packagist"
+		}
+	],
+	"packageRules": [
+		{
+			"extends": [
+				":automergeDisabled"
+			],
+			"matchManagers": [
+				"regex"
+			]
+		}
 	]
 }


### PR DESCRIPTION
This PR configures Renovate to update version constraints in the following files:

* `config.yaml` with special package configuration
* `templates/src/composer.json.twig` for each configured dependency