### PR TITLE
[BUGFIX] Remove `config/*` references from `.gitignore`

### DIFF
--- a/templates/src/.gitignore.twig
+++ b/templates/src/.gitignore.twig
@@ -12,13 +12,6 @@
 /public/typo3conf/*
 !/public/typo3conf/LocalConfiguration.php
 !/public/typo3conf/AdditionalConfiguration.php
-{% else %}
-!/config/
-/config/*
-!/config/system/
-/config/system/*
-!/config/system/additional.php
-!/config/system/settings.php
 {% endif %}
 
 # Temporary files


### PR DESCRIPTION
Using this template inserts a `.gitignore` in the newly created project that prevents from commiting the usually needed `config/*` directory in versions !== v11. Therefore, this PR seeks to allow the VCS coverage by default.