### PR TITLE
[TASK] Drop `roave/security-advisories` from `composer.json` template

### DIFF
--- a/templates/src/composer.json.twig
+++ b/templates/src/composer.json.twig
@@ -56,7 +56,6 @@
 {% if features.phpstan %}
 		"phpstan/extension-installer": "^1.2",
 {% endif %}
-		"roave/security-advisories": "dev-latest",
 {% if features.phpstan %}
 		"saschaegerer/phpstan-typo3": "{{ features.phpstan }}",
 {% endif %}


### PR DESCRIPTION
Composer 2.10 ships with policy filters – a mechanism that makes the usage of `roave/security-advisories` obsolete.